### PR TITLE
added media.conf to configure the m5_authority

### DIFF
--- a/5gms-docker-setup/recipe1/Dockerfile-Application-Provider
+++ b/5gms-docker-setup/recipe1/Dockerfile-Application-Provider
@@ -12,7 +12,7 @@ RUN apt-get update && \
     && apt-get clean
 
 # Clone the repository
-RUN git clone --recurse-submodules https://github.com/5G-MAG/rt-5gms-application-provider
+RUN git clone -b feature/90-metric-name-space-and-metrics-consumption-ui-polish-clean https://github.com/5G-MAG/rt-5gms-application-provider.git /rt-5gms-application-provider
 
 # Set working directory
 WORKDIR /rt-5gms-application-provider

--- a/5gms-docker-setup/recipe1/Readme.md
+++ b/5gms-docker-setup/recipe1/Readme.md
@@ -24,15 +24,15 @@ and exposes reference points `M1`, `M4`, `M5` and `M8`.
 
 ### Configuration files
 
-You need to provide two configuration changes to the `af-sync.conf` and the `streams.json` file.
+You need to provide two configuration changes to the `media.conf` and the `initial-config.json` file.
 
-In `af-sync.conf` add the IP of your host machine by replacing `<<ADD_YOUR_IP_HERE>>` e.g.:
+In `media.conf` add the IP of your host machine by replacing `<<ADD_YOUR_IP_HERE>>` e.g.:
 
 ````
 m5_authority = 10.147.67.219:7778
 ````
 
-In `streams.json` add the IP of your host machine by replacing `<<ADD_YOUR_IP_HERE>>` e.g.:
+In `initial-config.json` add the IP of your host machine by replacing `<<ADD_YOUR_IP_HERE>>` e.g.:
 
 ````
 "domainNameAlias": "10.147.67.219"

--- a/5gms-docker-setup/recipe1/application-provider-entrypoint.sh
+++ b/5gms-docker-setup/recipe1/application-provider-entrypoint.sh
@@ -3,7 +3,6 @@
 # Set right port and IP
 m1-session configure set m1_port $M1_PORT
 m1-session configure set m1_address application-function
-m1-session configure set m5_authority $M5_AUTHORITY
 
 # Run the msaf-configuration tool if the flag is set
 if [ "$RUN_MSAF_CONFIGURATION_TOOL" = "true" ]; then

--- a/5gms-docker-setup/recipe1/docker-compose.yml
+++ b/5gms-docker-setup/recipe1/docker-compose.yml
@@ -31,13 +31,13 @@ services:
             - "8000:8000"
         volumes:
             - ./initial-config.json:/etc/rt-5gms/initial-config.json
+            - ./media.conf:/etc/rt-5gms/media.conf
             - ./shared:/usr/share/nginx/html
         depends_on:
             - application-function
             - application-server
         environment:
             - M1_PORT=5555
-            - M5_AUTHORITY=192.168.178.56:7778
             - RUN_MSAF_CONFIGURATION_TOOL=true
             - RUN_MANAGEMENT_UI=true
             - OPTIONS_ENDPOINT=http://application-function:5555/3gpp-m1/v2/provisioning-sessions/

--- a/5gms-docker-setup/recipe1/initial-config.json
+++ b/5gms-docker-setup/recipe1/initial-config.json
@@ -7,7 +7,7 @@
       "ingestURL": "https://rdmedia.bbc.co.uk/",
       "distributionConfigurations": [
         {
-          "domainNameAlias": "192.168.178.56"
+          "domainNameAlias": "<<ADD_YOUR_IP_HERE>>"
         }
       ],
       "consumptionReporting": {

--- a/5gms-docker-setup/recipe1/media.conf
+++ b/5gms-docker-setup/recipe1/media.conf
@@ -1,0 +1,6 @@
+[media-configuration]
+m5_authority = <<ADD_YOUR_IP_HERE>>:7778
+format = FiveGMagJsonFormatter
+root_dir = /usr/share/nginx/html/m8
+m8outputs = %(format)s(root_dir=%(root_dir)s)
+


### PR DESCRIPTION
## Summary
- this PR uses the media.conf config file 
- the m8 is hosted now by the AP
  - for the PR  the feature/90-metric-name-space-and-metrics-consumption-ui-polish-clean branch is loaded