### PR TITLE
Add optional maf-client configuration to enable feature

### DIFF
--- a/5gms-docker-setup/recipe1/Dockerfile-Application-Provider
+++ b/5gms-docker-setup/recipe1/Dockerfile-Application-Provider
@@ -12,7 +12,7 @@ RUN apt-get update && \
     && apt-get clean
 
 # Clone the repository
-RUN git clone --recurse-submodules -b development https://github.com/5G-MAG/rt-5gms-application-provider.git /rt-5gms-application-provider
+RUN git clone --recurse-submodules -b feature/102-track-external-provisioning-sessions https://github.com/5G-MAG/rt-5gms-application-provider.git /rt-5gms-application-provider
 
 # Set working directory
 WORKDIR /rt-5gms-application-provider

--- a/5gms-docker-setup/recipe1/Dockerfile-Application-Provider
+++ b/5gms-docker-setup/recipe1/Dockerfile-Application-Provider
@@ -12,7 +12,7 @@ RUN apt-get update && \
     && apt-get clean
 
 # Clone the repository
-RUN git clone --recurse-submodules -b feature/102-track-external-provisioning-sessions https://github.com/5G-MAG/rt-5gms-application-provider.git /rt-5gms-application-provider
+RUN git clone --recurse-submodules -b development https://github.com/5G-MAG/rt-5gms-application-provider.git /rt-5gms-application-provider
 
 # Set working directory
 WORKDIR /rt-5gms-application-provider

--- a/5gms-docker-setup/recipe1/application-provider-entrypoint.sh
+++ b/5gms-docker-setup/recipe1/application-provider-entrypoint.sh
@@ -1,5 +1,17 @@
 #!/bin/sh
 
+if [ "$USE_MAF_CLIENT_CONF" = "true" ]; then
+    if [ -f /tmp/maf-client.conf ]; then
+        mkdir -p /etc/rt-5gms
+        cp /tmp/maf-client.conf /etc/rt-5gms/maf-client.conf
+        echo "Copied maf-client.conf into /etc/rt-5gms"
+    else
+        echo "USE_MAF_CLIENT_CONF is true, but /tmp/maf-client.conf is missing"
+    fi
+else
+    echo "USE_MAF_CLIENT_CONF flag disabled, not copying maf-client.conf"
+fi
+
 # Set right port and IP
 m1-session configure set m1_port $M1_PORT
 m1-session configure set m1_address application-function

--- a/5gms-docker-setup/recipe1/docker-compose.yml
+++ b/5gms-docker-setup/recipe1/docker-compose.yml
@@ -33,6 +33,7 @@ services:
         volumes:
             - ./initial-config.json:/etc/rt-5gms/initial-config.json
             - ./media.conf:/etc/rt-5gms/media.conf
+            - ./maf-client.conf:/tmp/maf-client.conf:ro
             - ./shared:/usr/share/nginx/html
         depends_on:
             - application-function
@@ -41,6 +42,7 @@ services:
             - M1_PORT=5555
             - RUN_MSAF_CONFIGURATION_TOOL=true
             - RUN_MANAGEMENT_UI=true
+            - USE_MAF_CLIENT_CONF=false
             - OPTIONS_ENDPOINT=http://application-function:5555/3gpp-m1/v2/provisioning-sessions/
 
 

--- a/5gms-docker-setup/recipe1/maf-client.conf
+++ b/5gms-docker-setup/recipe1/maf-client.conf
@@ -1,0 +1,6 @@
+[maf-client]
+log_level = info
+maf_address = application-function
+maf_port = 6464
+auto_discover = false
+


### PR DESCRIPTION
# Summary

In `/rt-5G/rt-5gms-examples/5gms-docker-setup/recipe1/docker-compose.yml`, the environment variable `USE_MAF_CLIENT_CONF` acts as a flag. If this flag is set to true, the `maf-client.conf` file is copied to the `/etc/rt-5gms directory`, which enables the feature for tracking externally created provisioning sessions in the AP.

If the flag is set to false, the feature is disabled because the configuration file is not copied to the `/etc/rt-5gms` directory.